### PR TITLE
Remove the quotes around the example project name

### DIFF
--- a/bulk-site-create-clone.sh
+++ b/bulk-site-create-clone.sh
@@ -17,7 +17,7 @@ echo -e "Welcome to the Pantheon bulk site creation script\n\n"
 
 # Site prefix
 echo -e "What project name would you like to use?"
-echo -e "e.g. 'My Cool Training'\n"
+echo -e "e.g. My Cool Training\n"
 read -p 'Project Name: ' PROJECT_NAME
 PROJECT_SLUG=$(echo "$PROJECT_NAME" | tr '[:upper:]' '[:lower:]')
 PROJECT_SLUG=$(echo "$PROJECT_SLUG" | tr '[:space:]' '-')


### PR DESCRIPTION
When running through the script, it says `e.g. 'My Cool Training'`. If you type in literally `'My Cool Training'` it fails because of the quotes. This commit removes the quotes from the example.