### PR TITLE
Add Pantheon tag for project and make the student the owner of the site

### DIFF
--- a/bulk-site-create-clone.sh
+++ b/bulk-site-create-clone.sh
@@ -129,12 +129,12 @@ do
     fi
 
 	# Add the user to the Pantheon team
-    echo -e "Adding the Pantheon user $PANTHEON_EMAIL to the $DESTINATION_NAME site...\n"
+	echo -e "Adding the Pantheon user $PANTHEON_EMAIL to the $DESTINATION_NAME site...\n"
 	terminus site:team:add ${DESTINATION_UUID} ${PANTHEON_EMAIL}
 	
        # Make the user the owner of the site
-    echo -e "Making the Pantheon user $PANTHEON_EMAIL the owner of the $DESTINATION_NAME site...\n"
-       terminus owner:set $DESTINATION_NAME ${PANTHEON_EMAIL}
+       # echo -e "Making the Pantheon user $PANTHEON_EMAIL the owner of the $DESTINATION_NAME site...\n"
+       # terminus owner:set $DESTINATION_NAME ${PANTHEON_EMAIL}
 
 # if we are not at the end of the file, we are not done, loop again
 done < $INPUT

--- a/bulk-site-create-clone.sh
+++ b/bulk-site-create-clone.sh
@@ -121,9 +121,12 @@ do
         echo -e "Cloning code, database and files from the $SOURCE to $DESTINATION. This may take a while...\n\n"
         terminus site:clone $SOURCE $DESTINATION --yes
     fi
+    
 	# Add a tag to the site for the project
-    echo -e "Adding the tag $PROJECT_SLUG to the $DESTINATION_NAME site...\n"
-    	terminus tag:add $DESTINATION_NAME ${ORG_UUID} $PROJECT_SLUG
+    if [ ! -z $ORG_UUID ]; then
+	echo -e "Adding the tag $PROJECT_SLUG to the $DESTINATION_NAME site...\n"
+	terminus tag:add $DESTINATION_NAME ${ORG_UUID} $PROJECT_SLUG
+    fi
 
 	# Add the user to the Pantheon team
     echo -e "Adding the Pantheon user $PANTHEON_EMAIL to the $DESTINATION_NAME site...\n"

--- a/bulk-site-create-clone.sh
+++ b/bulk-site-create-clone.sh
@@ -121,10 +121,17 @@ do
         echo -e "Cloning code, database and files from the $SOURCE to $DESTINATION. This may take a while...\n\n"
         terminus site:clone $SOURCE $DESTINATION --yes
     fi
+	# Add a tag to the site for the project
+    echo -e "Adding the tag $PROJECT_SLUG to the $DESTINATION_NAME site...\n"
+    	terminus tag:add $DESTINATION_NAME ${ORG_UUID} $PROJECT_SLUG
 
 	# Add the user to the Pantheon team
     echo -e "Adding the Pantheon user $PANTHEON_EMAIL to the $DESTINATION_NAME site...\n"
 	terminus site:team:add ${DESTINATION_UUID} ${PANTHEON_EMAIL}
+	
+       # Make the user the owner of the site
+    echo -e "Making the Pantheon user $PANTHEON_EMAIL the owner of the $DESTINATION_NAME site...\n"
+       terminus owner:set $DESTINATION_NAME ${PANTHEON_EMAIL}
 
 # if we are not at the end of the file, we are not done, loop again
 done < $INPUT


### PR DESCRIPTION
We expect each trainer to have a single org for all of their classes. To help filter by class, we're going to add a tag for each class. The first bit of this handles that based on the project name.

The second bit of code makes the student the owner of the site. The only problem with this, is that it introduces an error message from Pantheon if the user is already the owner (if I spin up a site for myself, which is minor) or if the user does not yet have a Pantheon account (which may happen frequently with students. Fortunately the error doesn't break anything - the original site creator remains the owner if the command fails.